### PR TITLE
add sizes argument to Headers::add_link

### DIFF
--- a/src/AsyncWeb/HTML/Headers.php
+++ b/src/AsyncWeb/HTML/Headers.php
@@ -36,7 +36,7 @@ class Headers{
   Headers::$headers[md5("script__".$type."__".$src)] = array("tag"=>"script","type"=>$type,"src"=>$src);
  }
  
- public static function add_link($href="",$rel="",$type="",$title="",$media=""){
+ public static function add_link($href="",$rel="",$type="",$title="",$media="",$sizes=""){
   $arr = array();
   $arr["tag"]="link";
   
@@ -45,7 +45,8 @@ class Headers{
   if($type  !="") $arr["type"]=$type;
   if($title !="") $arr["title"]=$title;
   if($media !="") $arr["media"]=$media;
-  
+  if($sizes !="") $arr["sizes"]=$sizes;
+ 
   Headers::$headers[md5("link__".$type."__".$rel."__".$href)] = $arr;
  }
  public static $showHeadTags = false;

--- a/src/AsyncWeb/Menu/Builder/Class.php
+++ b/src/AsyncWeb/Menu/Builder/Class.php
@@ -1,6 +1,0 @@
-<?php
-
-namespace AsyncWeb\Menu\Builder;
-
-class Class extends \AsyncWeb\Helpers\ValueObject {}
-

--- a/src/AsyncWeb/Menu/Builder/Clazz.php
+++ b/src/AsyncWeb/Menu/Builder/Clazz.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace AsyncWeb\Menu\Builder;
+
+class Clazz extends \AsyncWeb\Helpers\ValueObject {}
+

--- a/src/AsyncWeb/Menu/MenuItemBuilder.php
+++ b/src/AsyncWeb/Menu/MenuItemBuilder.php
@@ -33,7 +33,7 @@ class MenuItemBuilder{
 			if(is_a($arg,"\\AsyncWeb\\Menu\\Builder\\Submenu")){
 				$submenu = $arg->get();
 			}else
-			if(is_a($arg,"\\AsyncWeb\\Menu\\Builder\\Class")){
+			if(is_a($arg,"\\AsyncWeb\\Menu\\Builder\\Clazz")){
 				$class = $arg->get();
 			}else
 			if(is_a($arg,"\\AsyncWeb\\Menu\\Builder\\Type")){


### PR DESCRIPTION
We need sizes argument for favicons:
```

<link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png">
<link rel="apple-touch-icon" sizes="60x60" href="/apple-icon-60x60.png">
<link rel="apple-touch-icon" sizes="72x72" href="/apple-icon-72x72.png">
<link rel="apple-touch-icon" sizes="76x76" href="/apple-icon-76x76.png">
<link rel="apple-touch-icon" sizes="114x114" href="/apple-icon-114x114.png">
<link rel="apple-touch-icon" sizes="120x120" href="/apple-icon-120x120.png">
<link rel="apple-touch-icon" sizes="144x144" href="/apple-icon-144x144.png">
<link rel="apple-touch-icon" sizes="152x152" href="/apple-icon-152x152.png">
<link rel="apple-touch-icon" sizes="180x180" href="/apple-icon-180x180.png">
<link rel="icon" type="image/png" sizes="192x192"  href="/android-icon-192x192.png">
<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
<link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
<link rel="manifest" href="/manifest.json">
<meta name="msapplication-TileColor" content="#ffffff">
<meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
<meta name="theme-color" content="#ffffff">
```